### PR TITLE
Allow PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you discover any security related issues, please email hello@shapeandshift.de
 
 ### Requirements
 - ext-curl
-- PHP 7.4
+- PHP 7.4 / 8.0
 - vin-sw/shopware-php-sdk >= 1.0
 
 This SDK is mainly dedicated to Shopware 6.4 and onwards, earlier SW application may still be usable without test

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "require": {
         "vin-sw/shopware-sdk": "^1.0",
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "symfony/psr-http-message-bridge": "*"
     },


### PR DESCRIPTION
Allow PHP 8 in `composer.json` so that it can be used when running Laravel on PHP 8.